### PR TITLE
Switch from dgraph-io/dgo/v230 to billprovince/dgo.

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230"
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 const (

--- a/cloud_test.go
+++ b/cloud_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230"
+	"github.com/billprovince/dgo"
 )
 
 func TestDialCLoud(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230"
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 func TestTxnErrFinished(t *testing.T) {

--- a/example_get_schema_test.go
+++ b/example_get_schema_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 func Example_getSchema() {

--- a/example_set_object_test.go
+++ b/example_set_object_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 type School struct {

--- a/examples_test.go
+++ b/examples_test.go
@@ -26,8 +26,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/dgraph-io/dgo/v230"
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dgraph-io/dgo/v230
+module github.com/billprovince/dgo
 
 go 1.19
 
@@ -20,5 +20,3 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
-
-retract v230.0.0 // needed to merge #158 for v230.0.0 release

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 // LoginParams stores the information needed to perform a login request.

--- a/txn.go
+++ b/txn.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 var (

--- a/type_system_test.go
+++ b/type_system_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230"
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 var (

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230"
-	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/billprovince/dgo"
+	"github.com/billprovince/dgo/protos/api"
 )
 
 func TestCondUpsertCorrectingName(t *testing.T) {


### PR DESCRIPTION
This is a required step for compiling and getting "good" behavior, afaik.
In any case, it is a prerequisite for the later work of updating the client protos.